### PR TITLE
Update backoff version to match analytics-python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requires = [
     "requests>=2.7,<3.0",
     "six>=1.4",
     "monotonic>=1.5",
-    "backoff==1.6.0",
+    "backoff~=1.10.0",
     "python-dateutil>2.1"
 ]
 


### PR DESCRIPTION
## Description of the change

Update the version of the backoff library in setup.py. 

We are using both the segmentio/analytics-python library and your python library. The fact that your library is pinned to 1.6.0 and the segmentio library is pinned to ~= 1.10.0 is causing us a problem with our dependencies. 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
