### PR TITLE
Bump `backoff` dependency to `>=2.1`

### DIFF
--- a/rudder_analytics/version.py
+++ b/rudder_analytics/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.0.5'
+VERSION = '1.0.6'

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,9 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'rudder_analytics'))
 from version import VERSION
 
 long_description = '''
-RudderStack is a platform for collecting, storing and routing customer event data to dozens 
-of tools. RudderStack is open-source, can run in your cloud environment 
-(AWS, GCP, Azure or even your data-centre) and provides a powerful transformation 
+RudderStack is a platform for collecting, storing and routing customer event data to dozens
+of tools. RudderStack is open-source, can run in your cloud environment
+(AWS, GCP, Azure or even your data-centre) and provides a powerful transformation
 framework to process your event data on the fly.
 '''
 
@@ -21,7 +21,7 @@ install_requires = [
     "requests>=2.7,<3.0",
     "six>=1.4",
     "monotonic>=1.5",
-    "backoff~=1.10",
+    "backoff>=2.1",
     "python-dateutil>2.1"
 ]
 


### PR DESCRIPTION
## Description of the change
This PR bumps the dependency `backoff~=1.10` to `backoff>=2.1` (latest is 2.1.2). I was experiencing conflicts with other packages that have already updated their backoff dependency beyond `backoff~=1.10`.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

### Development
There are no changes to the `rudder-sdk-python` code. List below does not apply.
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
