### PR TITLE
fix: string formatting

### DIFF
--- a/rudderstack/analytics/client.py
+++ b/rudderstack/analytics/client.py
@@ -276,7 +276,7 @@ class Client(object):
         # Check message size.
         msg_size = len(json.dumps(msg, cls=DatetimeSerializer).encode())
         if msg_size > MAX_MSG_SIZE:
-            raise RuntimeError('Message exceeds %skb limit. (%s)', str(int(MAX_MSG_SIZE / 1024)), str(msg))
+            raise RuntimeError(f'Message exceeds {str(int(MAX_MSG_SIZE / 1024))}kb limit. ({str(msg)})')
 
         # if send is False, return msg as if it was successfully queued
         if not self.send:


### PR DESCRIPTION
## Description of the change

Fix string formatting for message size limit runtime error.

Before:
```
RuntimeError: ('Message exceeds %skb limit. (%s)', '32', "{'integrations': ...
```

After:
```
RuntimeError: Message exceeds 32kb limit. ({'integrations': ...
```

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
