### PR TITLE
chore: add DeepWiki badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # RudderStack Python SDK
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/rudderlabs/rudder-sdk-python)
+
 RudderStack’s Python SDK lets you track events from your Python application. Once enabled, the event requests hit the RudderStack servers. RudderStack then transforms and routes these events to your specified destination platforms.
 
 More details on the Python SDK can be found in our [**documentation**](https://docs.rudderstack.com/stream-sources/rudderstack-sdk-integration-guides/rudderstack-python-sdk)


### PR DESCRIPTION
## Summary

Add a DeepWiki badge to the top of the README, linking to the DeepWiki page for this repository (`https://deepwiki.com/rudderlabs/rudder-sdk-python`).

## Changes

- Added a clickable DeepWiki badge (`[![Ask DeepWiki](https://deepwiki.com/badge.svg)]`) to `README.md`, placed directly below the title heading.

## Test plan

- [ ] Verify the badge image renders correctly on GitHub.
- [ ] Verify the badge links to the correct DeepWiki page.
